### PR TITLE
Features/add formatted float struct

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ XML-RPC only allows limited parameter types. We map these to Elixir as follows:
 | `<string>`           | Bitstring, eg "string"    |
 | `<int>` (`<i4>`)     | Integer, eg 17            |
 | `<double>`           | Float, eg -12.3           |
-| `<double>`           | %XMLRPC.FormattedFloat, eg {"~.2f", 1.23}            |
+| `<double>`           | %XMLRPC.FormattedFloat, eg {1.23, "~.2f"}            |
 | `<array>`            | List, eg [1, 2, 3]        |
 | `<struct>`           | Map, eg %{key: "value"}   |
 | `<dateTime.iso8601>` | %XMLRPC.DateTime          |

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ XML-RPC only allows limited parameter types. We map these to Elixir as follows:
 | `<string>`           | Bitstring, eg "string"    |
 | `<int>` (`<i4>`)     | Integer, eg 17            |
 | `<double>`           | Float, eg -12.3           |
+| `<double>`           | %XMLRPC.FormattedFloat, eg {"~.2f", 1.23}            |
 | `<array>`            | List, eg [1, 2, 3]        |
 | `<struct>`           | Map, eg %{key: "value"}   |
 | `<dateTime.iso8601>` | %XMLRPC.DateTime          |

--- a/lib/xml_rpc/encoder.ex
+++ b/lib/xml_rpc/encoder.ex
@@ -164,6 +164,13 @@ defimpl XMLRPC.ValueEncoder, for: XMLRPC.Base64 do
   end
 end
 
+defimpl XMLRPC.ValueEncoder, for: XMLRPC.FormattedFloat do
+  import XMLRPC.Encode, only: [tag: 2]
+
+  def encode(%XMLRPC.FormattedFloat{raw: _} = formatted_float, _options) do
+    tag("double", XMLRPC.FormattedFloat.to_binary(formatted_float))
+  end
+end
 
 defimpl XMLRPC.ValueEncoder, for: List do
   import XMLRPC.Encode, only: [tag: 2]

--- a/lib/xml_rpc/formatted_float.ex
+++ b/lib/xml_rpc/formatted_float.ex
@@ -9,7 +9,7 @@ defmodule XMLRPC.FormattedFloat do
   @doc """
   Create a new FormattedFloat struct
   """
-  def new({float, pattern}) do
+  def new({float, pattern}) when is_float(float) and is_binary(pattern) do
     %__MODULE__{raw: {float, pattern}}
   end
 

--- a/lib/xml_rpc/formatted_float.ex
+++ b/lib/xml_rpc/formatted_float.ex
@@ -1,0 +1,22 @@
+defmodule XMLRPC.FormattedFloat do
+  @moduledoc """
+  Elixir datatype to store formatted float value
+
+  """
+  @type t :: %__MODULE__{raw: String.t()}
+  defstruct raw: ""
+
+  @doc """
+  Create a new FormattedFloat struct
+  """
+  def new({float, pattern}) do
+    %__MODULE__{raw: {float, pattern}}
+  end
+
+  @doc """
+  Attempt convert struct to binary
+  """
+  def to_binary(%__MODULE__{raw: {float, pattern}}) do
+    :io_lib.format(pattern, [float]) |> IO.iodata_to_binary()
+  end
+end

--- a/test/xmlrpc_test.exs
+++ b/test/xmlrpc_test.exs
@@ -3,6 +3,7 @@ defmodule XMLRPC.DecoderTest do
   doctest XMLRPC
   doctest XMLRPC.DateTime
   doctest XMLRPC.Base64
+  doctest XMLRPC.FormattedFloat
 
   @rpc_simple_call_1 """
 <?xml version="1.0" encoding="UTF-8"?>
@@ -312,6 +313,26 @@ MjIzMzQ0NTU2Njc3ODg5OQ==
 
   @rpc_base64_call_1_elixir_to_encode %XMLRPC.MethodCall{method_name: "sample.fun1", params: [true,
                                                                                               XMLRPC.Base64.new(@rpc_base64_value)]}
+  @rpc_formatted_float_call """
+  <?xml version="1.0" encoding="UTF-8"?>
+  <methodCall>
+    <methodName>sample.fun1</methodName>
+    <params>
+      <param>
+        <value>
+          <double>-13.53</double>
+        </value>
+      </param>
+    </params>
+  </methodCall>
+  """
+
+  @rpc_formatted_float_value -13.53
+
+  @rpc_formatted_float_to_encode %XMLRPC.MethodCall{
+    method_name: "sample.fun1",
+    params: [%XMLRPC.FormattedFloat{raw: {-13.53456, "~.2f"}}]
+  }
 
   # Various malformed tags
   @rpc_response_invalid_1 """
@@ -509,6 +530,13 @@ MjIzMzQ0NTU2Njc3ODg5OQ==
                  |> IO.iodata_to_binary
 
     assert encode == strip_space(@rpc_base64_call_1)
+  end
+
+  test "encode formated float data" do
+    encode = XMLRPC.encode!(@rpc_formatted_float_to_encode)
+             |> IO.iodata_to_binary
+
+    assert encode == strip_space(@rpc_formatted_float_call)
   end
 
   test "encode rpc_response_invalid_3" do

--- a/test/xmlrpc_test.exs
+++ b/test/xmlrpc_test.exs
@@ -327,8 +327,6 @@ MjIzMzQ0NTU2Njc3ODg5OQ==
   </methodCall>
   """
 
-  @rpc_formatted_float_value -13.53
-
   @rpc_formatted_float_to_encode %XMLRPC.MethodCall{
     method_name: "sample.fun1",
     params: [%XMLRPC.FormattedFloat{raw: {-13.53456, "~.2f"}}]


### PR DESCRIPTION
Issue:
When we converting float to string, we can see repeating decimal there should be a fixed number of characters after point (128.39 -> "128.38999999999999").
For example:
```
iex(1)>  %XMLRPC.MethodCall{method_name: "test", params: [127.39]} |> XMLRPC.encode!  
"<?xml version="1.0" encoding="UTF-8"?>
<methodCall>
  <methodName>test</methodName>
  <params>
    <param>
      <value>
        <double>127.39</double>
      </value>
    </param>
  </params>
</methodCall>"
```
```
iex(2)>  %XMLRPC.MethodCall{method_name: "test", params: [128.39]} |> XMLRPC.encode!  
"<?xml version="1.0" encoding="UTF-8"?>
<methodCall>
  <methodName>test</methodName>
  <params>
    <param>
      <value>
        <double>128.3888888889</double>
      </value>
    </param>
  </params>
</methodCall>"
```

The problem lies in the declared accuracy of calculations :erlang.float_to_binary
This problem can be solved by using [options] as parameter of encoding/2 function.

For example:
```
    tag("double", Float.to_string(double, options
                                          |> Keyword.put_new(:compact, true)
                                          |> Keyword.put_new(:decimals, 14))
```
But it only generic solution, because we may need many different float values.

My final solution - formatted struct:
`%XMLRPC.FormattedFloat.new({1.2345, "~.2f"}) |> XMLRPC.to_binary() -> "1.23"`